### PR TITLE
Fix URL to Homepage

### DIFF
--- a/justl.el
+++ b/justl.el
@@ -22,7 +22,7 @@
 ;; Version: 0.2
 ;; Author: Sibi Prabakaran
 ;; Keywords: just justfile tools processes
-;; URL: https://github.com/psibi/justl
+;; URL: https://github.com/psibi/justl.el
 ;; License: GNU General Public License >= 3
 ;; Package-Requires: ((transient "0.1.0") (emacs "25.3") (xterm-color "2.0") (s "1.2.0") (f "0.20.0"))
 


### PR DESCRIPTION
Broken linked from package information.

<img width="626" alt="スクリーンショット 2021-09-20 7 42 35" src="https://user-images.githubusercontent.com/822086/133945344-5677ad24-eb67-4f4f-8c05-3a3ef6ffae7d.png">


