### PR TITLE
Add Unstable flag to transient

### DIFF
--- a/README.org
+++ b/README.org
@@ -75,6 +75,9 @@ W => open eshell without executing
 
 * Customize
 
+- Because the help popup is built with transient, you can [[https://www.gnu.org/software/emacs//manual/html_node/transient/Saving-Values.html][set and save
+  your choices]] the same way you would with any other transient
+  dialog.
 - By default, justl searches the executable named *just*, you can
   change the /justl-executable/ variable to set any explicit path.
 - You can also control the width of the RECIPE column in the justl

--- a/justl.el
+++ b/justl.el
@@ -479,9 +479,12 @@ and output of process."
 
 (defun justl--get-recipies-with-desc (justfile)
   "Return all the recipies in JUSTFILE with description."
-  (let* ((recipe-status (justl--exec-to-string-with-exit-code
-                         (format "%s --justfile=%s --list --unsorted"
-                                 justl-executable justfile)))
+  (let* ((t-args (transient-args 'justl-help-popup))
+         (recipe-status (justl--exec-to-string-with-exit-code
+                         (format "%s %s --justfile=%s --list --unsorted"
+                                 justl-executable
+                                 (string-join t-args " ")
+                                 justfile)))
          (justl-status (nth 0 recipe-status))
          (recipe-lines (split-string
                         (nth 1 recipe-status)
@@ -622,6 +625,7 @@ tweaked further by the user."
     ("-n" "Disable Highlight" "--no-highlight")
     ("-q" "Quiet" "--quiet")
     ("-v" "Verbose output" "--verbose")
+    ("-u" "Unstable" "--unstable")
     (justl--color)
     ]
    ["Actions"
@@ -705,7 +709,7 @@ tweaked further by the user."
   (let* ((justfiles (justl--find-justfiles default-directory))
          (entries (justl--get-recipies-with-desc justfiles)))
     (when (not (eq justl--list-command-exit-code 0) )
-      (error "Just process exited with exit-code %s. Check justfile syntax"
+      (error "Just process exited with exit-code %s.  Check justfile syntax"
                justl--list-command-exit-code))
     (justl--save-line)
     (setq tabulated-list-entries (justl--tabulated-entries entries))

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -71,6 +71,9 @@
            (justl--is-recipe-line-p "# Terraform plan")
            nil))
   (should (equal
+           (justl--is-recipe-line-p "!include lorem.just")
+           nil))
+  (should (equal
            (justl--is-recipe-line-p "push version: (build-cmd version)")
            t))
   (should (equal


### PR DESCRIPTION
This PR adds the ability to define flags which are passed to the just
executable itself. This is needed if, for example, a justfile requires
the `--unstable` flag.