### PR TITLE
Promote `justl--justfile` to a safe, local defcustom

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - emacs-release-snapshot
+          - release-snapshot
           - 28.2
           - 27.2
         ignore_warnings:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
+          - emacs-release-snapshot
           - 28.2
           - 27.2
-          - 26.3
         ignore_warnings:
           - false
     steps:

--- a/justl.el
+++ b/justl.el
@@ -90,12 +90,6 @@
   :group 'justl
   :safe 'stringp)
 
-(defcustom justl-args ""
-  "Pass arguments to the just executable itself."
-  :type 'string
-  :group 'justl
-  :safe 'stringp)
-
 (defcustom justl-recipe-width 20
   "Width of the recipe column."
   :type 'integer
@@ -421,7 +415,7 @@ ARGS is a ist of arguments."
     (setq process-name justl-executable))
   (let ((buffer-name justl--output-process-buffer)
         (error-buffer (justl--process-error-buffer process-name))
-        (cmd (append (list justl-executable justl-args (justl--justfile-argument)) args))
+        (cmd (append (list justl-executable (justl--justfile-argument)) args))
         (mode 'justl-compile-mode))
     (when (get-buffer buffer-name)
       (kill-buffer buffer-name))
@@ -633,7 +627,6 @@ tweaked further by the user."
     ("-n" "Disable Highlight" "--no-highlight")
     ("-q" "Quiet" "--quiet")
     ("-v" "Verbose output" "--verbose")
-    ("-u" "Unstable" "--unstable")
     (justl--color)
     ]
    ["Actions"
@@ -717,7 +710,7 @@ tweaked further by the user."
   (let* ((justfiles (justl--find-justfiles default-directory))
          (entries (justl--get-recipies-with-desc justfiles)))
     (when (not (eq justl--list-command-exit-code 0) )
-      (error "Just process exited with exit-code %s. Check justfile syntax"
+      (error "Just process exited with exit-code %s.  Check justfile syntax"
                justl--list-command-exit-code))
     (justl--save-line)
     (setq tabulated-list-entries (justl--tabulated-entries entries))


### PR DESCRIPTION
This PR aims to make the justfile variable configurable from a `.dir-locals.el` file:

I currently have a project made up of many microservices which each have their own directory, along with a directory containing a justfile. I want to be able to call the justfile from any directory under the `.dir-locals.el` file at project root.

Before, I was doing this reliably by setting:

```
((nil . ((justl--justfile . "/home/john/code/work/utils/development/justfile"))))
```

But I would receive safe variable warnings that I couldn't figure out how to suppress without making changes to the package.