### PR TITLE
Tidyups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore"
+    include: "scope"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: extractions/setup-just@v1
       with:
-        just-version: 1.8.0
+        just-version: 1.10.0
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}

--- a/Changelog.org
+++ b/Changelog.org
@@ -1,3 +1,11 @@
+* Unreleased
+
+- Respect buffer-local environments, for compatibility with ~envrc.el~
+  when ~just~ is installed on a per-project basis.
+- Add ~justl-include-private-recipes~ to show private recipes in the
+  list (defaults to on).
+- Rewritten internals, using ~just~ itself to parse recipe information.
+
 * 0.13
 
 - TRAMP support

--- a/Changelog.org
+++ b/Changelog.org
@@ -101,7 +101,7 @@ finished and what it's exit status code looks like.
 - Add ability to turn off color in the output. Useful for eshell
   integration which doesn't recognize color without additional setup.
 
-- Integration with eshell done. You can now execute the recipies in
+- Integration with eshell done. You can now execute the recipes in
   either eshell or open eshell and give positional arguments etc for
   the recipe before executing it. The key binding for it is *E* and
   *W*.

--- a/justl.el
+++ b/justl.el
@@ -99,7 +99,7 @@
 (defcustom justl-justfile nil
   "Buffer local variable which points to the justfile.
 
-If this is NIL, it means that no justfiles was found.  In any
+If this is NIL, it means that no justfile was found.  In any
 other cases, it's a known path."
   :type 'string
   :local t
@@ -178,8 +178,8 @@ NAME is the buffer name."
       (insert (format "%s\n" str))
       (read-only-mode nil))))
 
-(defun justl--find-any-justfiles (dir)
-  "Find justfiles inside a sub-directory DIR or a parent directory.
+(defun justl--find-any-justfile (dir)
+  "Find justfile inside a sub-directory DIR or a parent directory.
 
 Returns the absolute path if file exists or nil if no path
 was found."
@@ -189,12 +189,12 @@ was found."
     (when-let ((location (locate-dominating-file dir #'any-justfile)))
       (expand-file-name (any-justfile location) location))))
 
-(defun justl--find-justfiles (dir)
-  "Find justfiles inside a sub-directory DIR or a parent directory.
+(defun justl--find-justfile (dir)
+  "Find justfile inside a sub-directory DIR or a parent directory.
 
 DIR represents the directory where search will be carried out.
 It searches either for the filename justfile or .justfile"
-  (when-let ((justfile-path (justl--find-any-justfiles dir)))
+  (when-let ((justfile-path (justl--find-any-justfile dir)))
     (setq-local justl-justfile justfile-path)
     justfile-path))
 
@@ -476,9 +476,9 @@ and output of process."
 (defun justl-exec-recipe-in-dir ()
   "Populate and execute the selected recipe."
   (interactive)
-  (let* ((justfile (justl--find-justfiles default-directory)))
+  (let* ((justfile (justl--find-justfile default-directory)))
     (if (not justfile)
-	(error "No justfiles found"))
+	(error "No justfile found"))
     (let* ((recipe (completing-read "Recipes: " (justl--get-recipes justfile)
                                     nil nil nil nil "default"))
 	   (justl-recipe (justl--get-recipe-from-file justfile recipe))
@@ -513,7 +513,7 @@ and output of process."
 
 (defun justl--buffer-name ()
   "Return justl buffer name."
-  (let ((justfile (justl--find-justfiles default-directory)))
+  (let ((justfile (justl--find-justfile default-directory)))
     (format "*just [%s]*"
             (f-dirname justfile))))
 
@@ -685,8 +685,8 @@ tweaked further by the user."
 (defun justl--refresh-buffer ()
   "Refresh justl buffer."
   (interactive)
-  (let* ((justfiles (justl--find-justfiles default-directory))
-         (entries (justl--get-recipes-with-desc justfiles)))
+  (let* ((justfile (justl--find-justfile default-directory))
+         (entries (justl--get-recipes-with-desc justfile)))
     (when (not (eq justl--list-command-exit-code 0) )
       (error "Just process exited with exit-code %s.  Check justfile syntax"
                justl--list-command-exit-code))
@@ -700,8 +700,8 @@ tweaked further by the user."
 (defun justl ()
   "Invoke the justl buffer."
   (interactive)
-  (unless (justl--find-justfiles default-directory)
-    (error "No justfiles found"))
+  (unless (justl--find-justfile default-directory)
+    (error "No justfile found"))
   (justl--save-line)
   (justl--pop-to-buffer (justl--buffer-name))
   (justl-mode))
@@ -710,12 +710,12 @@ tweaked further by the user."
   "Special mode for justl buffers."
   (buffer-disable-undo)
   (setq truncate-lines t)
-  (let* ((justfiles (justl--find-justfiles default-directory))
-	 (entries (justl--get-recipes-with-desc justfiles)))
-    (if (or (null justfiles) (not (zerop justl--list-command-exit-code)) )
+  (let* ((justfile (justl--find-justfile default-directory))
+	 (entries (justl--get-recipes-with-desc justfile)))
+    (if (or (null justfile) (not (zerop justl--list-command-exit-code)) )
         (progn
-          (when (null justfiles)
-            (message "No justfiles found"))
+          (unless justfile
+            (message "No justfile found"))
           (when (not (eq justl--list-command-exit-code 0) )
             (message "Just process exited with exit-code %s"
                      justl--list-command-exit-code)))
@@ -727,7 +727,7 @@ tweaked further by the user."
       (tabulated-list-init-header)
       (tabulated-list-print t)
       (hl-line-mode 1)
-      (message (concat "Just: " (f-dirname justfiles))))))
+      (message (concat "Just: " (f-dirname justfile))))))
 
 (provide 'justl)
 ;;; justl.el ends here

--- a/justl.el
+++ b/justl.el
@@ -530,7 +530,7 @@ not executed."
   "Read a value for ARG from the minibuffer."
   (let ((default (justl--arg-default arg)))
     (read-from-minibuffer
-     (format "Just arg for `%s': " (justl--arg-name arg))
+     (format "Just arg for '%s': " (justl--arg-name arg))
      (pcase default
        (`("variable" ,name) name)
        ('nil nil)

--- a/justl.el
+++ b/justl.el
@@ -133,9 +133,7 @@ other cases, it's a known path."
   "Utility function to pop to buffer or create it.
 
 NAME is the buffer name."
-  (unless (get-buffer name)
-    (get-buffer-create name))
-  (pop-to-buffer-same-window name))
+  (pop-to-buffer-same-window (get-buffer-create name)))
 
 (defvar justl--last-command nil)
 

--- a/justl.el
+++ b/justl.el
@@ -435,12 +435,12 @@ and output of process."
           (buf-string (buffer-substring-no-properties (point-min) (point-max))))
       (list justl-status buf-string))))
 
-(defun justl--get-recipies (justfile)
-  "Return all the recipies from JUSTFILE."
-  (let ((recipies (split-string (justl--exec-to-string
+(defun justl--get-recipes (justfile)
+  "Return all the recipes from JUSTFILE."
+  (let ((recipes (split-string (justl--exec-to-string
                                  (format "%s --justfile=%s --summary --unsorted --color=never"
                                          justl-executable (tramp-file-local-name justfile))))))
-    (mapcar #'string-trim-right recipies)))
+    (mapcar #'string-trim-right recipes)))
 
 (defun justl--justfile-argument ()
   "Provides justfile argument with the proper location."
@@ -451,8 +451,8 @@ and output of process."
   (when arg
     (cadr (s-split "--justfile=" arg))))
 
-(defun justl--get-recipies-with-desc (justfile)
-  "Return all the recipies in JUSTFILE with description."
+(defun justl--get-recipes-with-desc (justfile)
+  "Return all the recipes in JUSTFILE with description."
   (let* ((t-args (transient-args 'justl-help-popup))
          (recipe-status (justl--exec-to-string-with-exit-code
                          (format "%s %s --justfile=%s --list --unsorted --color=never"
@@ -479,7 +479,7 @@ and output of process."
   (let* ((justfile (justl--find-justfiles default-directory)))
     (if (not justfile)
 	(error "No justfiles found"))
-    (let* ((recipe (completing-read "Recipies: " (justl--get-recipies justfile)
+    (let* ((recipe (completing-read "Recipes: " (justl--get-recipes justfile)
                                     nil nil nil nil "default"))
 	   (justl-recipe (justl--get-recipe-from-file justfile recipe))
 	   (recipe-has-args (justl--jrecipe-has-args-p justl-recipe)))
@@ -527,11 +527,11 @@ and output of process."
       (setq justl--line-number (+ 1 (count-lines 1 (point))))
     (setq justl--line-number nil)))
 
-(defun justl--tabulated-entries (recipies)
-  "Turn RECIPIES to tabulated entries."
+(defun justl--tabulated-entries (recipes)
+  "Turn RECIPES to tabulated entries."
   (mapcar (lambda (x)
-               (list nil (vector (nth 0 x) (justl--util-maybe (nth 1 x) ""))))
-          recipies))
+            (list nil (vector (nth 0 x) (justl--util-maybe (nth 1 x) ""))))
+          recipes))
 
 (defun justl--no-exec-with-eshell (recipe)
   "Opens eshell buffer but does not execute it.
@@ -686,7 +686,7 @@ tweaked further by the user."
   "Refresh justl buffer."
   (interactive)
   (let* ((justfiles (justl--find-justfiles default-directory))
-         (entries (justl--get-recipies-with-desc justfiles)))
+         (entries (justl--get-recipes-with-desc justfiles)))
     (when (not (eq justl--list-command-exit-code 0) )
       (error "Just process exited with exit-code %s.  Check justfile syntax"
                justl--list-command-exit-code))
@@ -711,7 +711,7 @@ tweaked further by the user."
   (buffer-disable-undo)
   (setq truncate-lines t)
   (let* ((justfiles (justl--find-justfiles default-directory))
-	 (entries (justl--get-recipies-with-desc justfiles)))
+	 (entries (justl--get-recipes-with-desc justfiles)))
     (if (or (null justfiles) (not (zerop justl--list-command-exit-code)) )
         (progn
           (when (null justfiles)
@@ -720,7 +720,7 @@ tweaked further by the user."
             (message "Just process exited with exit-code %s"
                      justl--list-command-exit-code)))
       (setq tabulated-list-format
-            (vector (list "RECIPIES" justl-recipe-width t)
+            (vector (list "RECIPES" justl-recipe-width t)
                     (list "DESCRIPTION" 20 t)))
       (setq tabulated-list-entries (justl--tabulated-entries entries))
       (setq tabulated-list-sort-key nil)

--- a/justl.el
+++ b/justl.el
@@ -369,8 +369,10 @@ Logs the command run."
                            t)))
     (let ((parsed (json-parse-string json :null-object nil :false-object nil :array-type 'list :object-type 'alist)))
       (cl-flet ((unsorted-index (r)
-                  (or (cl-position (let-alist (cdr r) .name) unsorted-recipes :test 'string=)
-                      (error "didn't find this in unsorted-recipes: %S" (let-alist (cdr r) .name)))))
+                  (let-alist (cdr r)
+                    (or (cl-position .name unsorted-recipes :test 'string=)
+                        ;; sort private commands last
+                        1000))))
         (let-alist parsed
           (cl-sort .recipes (lambda (a b) (< (unsorted-index a) (unsorted-index b))))
           parsed)))))

--- a/justl.el
+++ b/justl.el
@@ -514,7 +514,7 @@ and output of process."
 (defun justl--buffer-name ()
   "Return justl buffer name."
   (let ((justfile (justl--find-justfiles default-directory)))
-    (format "*just [%s]"
+    (format "*just [%s]*"
             (f-dirname justfile))))
 
 (defvar justl--line-number nil

--- a/justl.el
+++ b/justl.el
@@ -417,8 +417,8 @@ Empty string is returned if the arg has no default."
              justl-executable
              (cons recipe-name
                    (mapcar (lambda (arg) (read-from-minibuffer
-                                          (format "Just arg for %s:" (justl--arg-name arg))
-                                          (or (justl--arg-default arg) "")))
+                                          (format "Just arg for %s: " (justl--arg-name arg))
+                                          (justl--arg-default-as-string arg)))
                            (justl--recipe-args recipe)))))))
 
 (defun justl-exec-default-recipe ()
@@ -469,9 +469,8 @@ not executed."
               justl-executable
               (cons (justl--recipe-name recipe)
                     (append (transient-args 'justl-help-popup)
-                            (seq-filter 'identity
-                                        (mapcar 'justl--arg-default
-                                                (justl--recipe-args recipe))))))
+                            (mapcar 'justl--arg-default-as-string
+                                    (justl--recipe-args recipe)))))
              " "))
     (unless no-send
       (eshell-send-input))))
@@ -523,7 +522,7 @@ not executed."
              (cons (justl--recipe-name recipe)
                    (mapcar (lambda (arg) (read-from-minibuffer
                                           (format "Just arg for `%s': " (justl--arg-name arg))
-                                          (or (justl--arg-default arg) "")))
+                                          (justl--arg-default-as-string arg)))
                            (justl--recipe-args recipe)))))))
 
 (defun justl--exec-recipe-with-args ()

--- a/justl.el
+++ b/justl.el
@@ -552,7 +552,10 @@ not executed."
 
 (defun justl--get-recipe-under-cursor ()
   "Utility function to get the name of the recipe under the cursor."
-  (get-text-property 0 'recipe (aref (tabulated-list-get-entry) 0)))
+  (let ((entry (tabulated-list-get-entry)))
+    (if entry
+        (get-text-property 0 'recipe (aref entry 0))
+      (user-error "There is no recipe on the current line"))))
 
 (defun justl--refresh-buffer ()
   "Refresh justl buffer."

--- a/justl.el
+++ b/justl.el
@@ -154,11 +154,10 @@ NAME is the buffer name."
 
 (defun justl--is-recipe-line-p (str)
   "Check if string STR is a recipe line."
-  (let* ((string (or str "")))
-    (if (string-match "\\`[ \t\n\r]+" string)
-        nil
-      (and (not (justl--is-variable-p string))
-           (s-contains? ":" string)))))
+  (and str
+       (not (string-match "\\`[ \t\n\r]+" str))
+       (not (justl--is-variable-p str))
+       (s-contains? ":" str)))
 
 (defun justl--append-to-process-buffer (str)
   "Append string STR to the process buffer."

--- a/justl.el
+++ b/justl.el
@@ -347,7 +347,7 @@ Logs the command run."
     (justl--log-command "just-command" cmd)
     (inheritenv
      (with-temp-buffer
-       (let ((justl-status (apply 'call-process executable nil t nil args))
+       (let ((justl-status (apply 'process-file executable nil t nil args))
              (buf-string (buffer-substring-no-properties (point-min) (point-max))))
          (cons justl-status buf-string))))))
 
@@ -359,7 +359,7 @@ Logs the command run."
                  "--unstable" "--dump" "--dump-format=json")))
     (if (zerop (car result))
         (json-parse-string (cdr result) :null-object nil :false-object nil :array-type 'list :object-type 'alist)
-      (error "Couldn't read %s: %s exited with code %d" justfile justl-executable (car result)))))
+      (error "Couldn't read %s: %s exited with code %d" (tramp-file-local-name justfile) justl-executable (car result)))))
 
 (defun justl--get-recipes (justfile)
   "Return all the recipes from JUSTFILE.
@@ -387,6 +387,11 @@ They are returned as objects, as per the JSON output of \"just --dump\"."
 (defun justl--arg-default (arg)
   "Get the default value of argument ARG."
   (let-alist arg .default))
+
+(defun justl--arg-default-as-string (arg)
+  "Get the default value of argument ARG as a string.
+Empty string is returned if the arg has no default."
+  (if arg (format "%s" arg) ""))
 
 (defun justl--justfile-argument ()
   "Provides justfile argument with the proper location."

--- a/justl.el
+++ b/justl.el
@@ -259,14 +259,12 @@ STRING is the data returned by the PROC"
   (when (buffer-live-p (process-buffer proc))
     (with-current-buffer (process-buffer proc)
       (let ((inhibit-read-only t))
-        (unwind-protect
-            (progn
-              (widen)
-              (goto-char (marker-position (process-mark proc)))
-              (insert string)
-              (comint-carriage-motion (process-mark proc) (point))
-              (ansi-color-apply-on-region (process-mark proc) (point))
-              (set-marker (process-mark proc) (point))))))))
+        (widen)
+        (goto-char (marker-position (process-mark proc)))
+        (insert string)
+        (comint-carriage-motion (process-mark proc) (point))
+        (ansi-color-apply-on-region (process-mark proc) (point))
+        (set-marker (process-mark proc) (point))))))
 
 (defun justl-compilation-setup-buffer (buf dir mode &optional no-mode-line)
   "Setup the compilation buffer for just-compile-mode.

--- a/justl.el
+++ b/justl.el
@@ -122,10 +122,6 @@ other cases, it's a known path."
 NAME is the buffer name."
   (pop-to-buffer-same-window (get-buffer-create name)))
 
-(defvar justl--last-command nil)
-
-(defvar justl--list-command-exit-code 0)
-
 (defconst justl--process-buffer "*just-process*"
   "Just process buffer name.")
 
@@ -171,7 +167,6 @@ CMD is the just command as a list."
   (let ((cmd (if (listp cmd)
                  (string-join cmd " ")
                cmd)))
-    (setq justl--last-command cmd)
     (justl--append-to-process-buffer
      (format "[%s] \ncommand: %S" process-name cmd))))
 

--- a/justl.el
+++ b/justl.el
@@ -413,13 +413,13 @@ Empty string is returned if the arg has no default."
                                          (mapcar 'justl--recipe-name recipes)
                                          nil t nil nil))
            (recipe (cdr (assoc recipe-name recipes))))
-      (apply 'justl--exec-without-justfile
-             justl-executable
-             (cons recipe-name
-                   (mapcar (lambda (arg) (read-from-minibuffer
-                                          (format "Just arg for %s: " (justl--arg-name arg))
-                                          (justl--arg-default-as-string arg)))
-                           (justl--recipe-args recipe)))))))
+      (justl--exec-without-justfile
+       justl-executable
+       (cons recipe-name
+             (mapcar (lambda (arg) (read-from-minibuffer
+                                    (format "Just arg for %s: " (justl--arg-name arg))
+                                    (justl--arg-default-as-string arg)))
+                     (justl--recipe-args recipe)))))))
 
 (defun justl-exec-default-recipe ()
   "Execute default recipe."

--- a/justl.el
+++ b/justl.el
@@ -89,13 +89,11 @@
 (defcustom justl-executable "just"
   "Location of just executable."
   :type 'file
-  :group 'justl
   :safe 'stringp)
 
 (defcustom justl-recipe-width 20
   "Width of the recipe column."
-  :type 'integer
-  :group 'justl)
+  :type 'integer)
 
 (defcustom justl-justfile nil
   "Buffer local variable which points to the justfile.
@@ -104,7 +102,6 @@ If this is NIL, it means that no justfile was found.  In any
 other cases, it's a known path."
   :type 'string
   :local t
-  :group 'justl
   :safe 'stringp)
 
 (defcustom justl-include-private-recipes t

--- a/justl.el
+++ b/justl.el
@@ -278,17 +278,17 @@ directory and MODE is name of the Emacs mode.  NO-MODE-LINE
 controls if we are going to display the process status on mode line."
   (let ((inhibit-read-only t))
     (with-current-buffer buf
-    (erase-buffer)
-    (setq default-directory dir)
-    (funcall mode)
-    (unless no-mode-line
-      (setq mode-line-process
-            '((:propertize ":%s" face compilation-mode-line-run)
-              compilation-mode-line-errors)))
-    (force-mode-line-update)
-    (if (or compilation-auto-jump-to-first-error
-            (eq compilation-scroll-output 'first-error))
-        (set (make-local-variable 'compilation-auto-jump-to-next) t)))))
+      (erase-buffer)
+      (setq default-directory dir)
+      (funcall mode)
+      (unless no-mode-line
+        (setq mode-line-process
+              '((:propertize ":%s" face compilation-mode-line-run)
+                compilation-mode-line-errors)))
+      (force-mode-line-update)
+      (if (or compilation-auto-jump-to-first-error
+              (eq compilation-scroll-output 'first-error))
+          (set (make-local-variable 'compilation-auto-jump-to-next) t)))))
 
 (defvar justl--compile-command nil
   "Last shell command used to do a compilation; default for next compilation.")
@@ -348,10 +348,10 @@ ARGS is a plist that affects how the process is run.
     ("^Target execution \\(finished\\).*"
      (0 '(face nil compilation-message nil help-echo nil mouse-face nil) t)
      (1 compilation-info-face))
-        ("^Target execution \\(exited abnormally\\)\\(?:.*with code \\([0-9]+\\)\\)?.*"
-      (0 '(face nil compilation-message nil help-echo nil mouse-face nil) t)
-      (1 compilation-error-face)
-      (2 compilation-error-face nil t)))
+    ("^Target execution \\(exited abnormally\\)\\(?:.*with code \\([0-9]+\\)\\)?.*"
+     (0 '(face nil compilation-message nil help-echo nil mouse-face nil) t)
+     (1 compilation-error-face)
+     (2 compilation-error-face nil t)))
   "Things to highlight in justl-compile mode.")
 
 (define-compilation-mode justl-compile-mode "just-compile"
@@ -684,7 +684,7 @@ EXECUTABLE so that it can be tweaked further by the user."
          (entries (justl--get-recipes-with-desc justfile)))
     (when (not (eq justl--list-command-exit-code 0) )
       (error "Just process exited with exit-code %s.  Check justfile syntax"
-               justl--list-command-exit-code))
+             justl--list-command-exit-code))
     (justl--save-line)
     (setq tabulated-list-entries (justl--tabulated-entries entries))
     (tabulated-list-print t)

--- a/justl.el
+++ b/justl.el
@@ -370,8 +370,10 @@ Logs the command run."
                     (or (cl-position .name unsorted-recipes :test 'string=)
                         ;; sort private commands last
                         1000))))
-        (let-alist parsed
-          (cl-sort .recipes (lambda (a b) (< (unsorted-index a) (unsorted-index b))))
+        (let ((recipes-entry (assoc 'recipes parsed)))
+          (setcdr recipes-entry
+                  (seq-sort (lambda (a b) (< (unsorted-index a) (unsorted-index b)))
+                            (cdr recipes-entry)))
           parsed)))))
 
 (defun justl--get-recipes (justfile)

--- a/justl.el
+++ b/justl.el
@@ -113,24 +113,16 @@ other cases, it's a known path."
   "Check if JRECIPE has any arguments."
   (justl-jrecipe-args jrecipe))
 
-(defun justl--util-maybe (maybe default)
-  "Return the DEFAULT value if MAYBE is null.
-
-Similar to the fromMaybe function in the Haskell land."
-  (if (null maybe)
-  default
-  maybe))
-
 (defun justl--arg-to-str (jarg)
   "Convert JARG to just's positional argument."
   (format "%s=%s"
           (justl-jarg-arg jarg)
-          (justl--util-maybe (justl-jarg-default jarg) "")))
+          (or (justl-jarg-default jarg) "")))
 
 (defun justl--jrecipe-get-args (jrecipe)
   "Convert JRECIPE arguments to list of positional arguments."
   (let* ((recipe-args (justl-jrecipe-args jrecipe))
-         (args (justl--util-maybe recipe-args nil)))
+         (args recipe-args))
     (mapcar #'justl--arg-to-str args)))
 
 (defun justl--process-error-buffer (process-name)
@@ -164,7 +156,7 @@ NAME is the buffer name."
 
 (defun justl--is-recipe-line-p (str)
   "Check if string STR is a recipe line."
-  (let* ((string (justl--util-maybe str "")))
+  (let* ((string (or str "")))
     (if (string-match "\\`[ \t\n\r]+" string)
         nil
       (and (not (justl--is-variable-p string))
@@ -487,7 +479,7 @@ and output of process."
 	  (let* ((cmd-args (justl-jrecipe-args justl-recipe))
 		 (user-args (mapcar (lambda (arg) (read-from-minibuffer
                                                    (format "Just arg for %s:" (justl-jarg-arg arg))
-                                                   (justl--util-maybe (justl-jarg-default arg) "")))
+                                                   (or (justl-jarg-default arg) "")))
                                     cmd-args)))
             (justl--exec-without-justfile justl-executable
 					  (cons (justl-jrecipe-name justl-recipe) user-args)))
@@ -530,7 +522,7 @@ and output of process."
 (defun justl--tabulated-entries (recipes)
   "Turn RECIPES to tabulated entries."
   (mapcar (lambda (x)
-            (list nil (vector (nth 0 x) (justl--util-maybe (nth 1 x) ""))))
+            (list nil (vector (nth 0 x) (or (nth 1 x) ""))))
           recipes))
 
 (defun justl--no-exec-with-eshell (recipe)
@@ -560,7 +552,7 @@ tweaked further by the user."
     (if recipe-has-args
         (let* ((cmd-args (justl-jrecipe-args justl-recipe))
                (user-args (mapcar (lambda (arg)
-                                    (format "%s " (justl--util-maybe (justl-jarg-default arg) "")))
+                                    (format "%s " (or (justl-jarg-default arg) "")))
                                   cmd-args)))
           (justl--no-exec-with-eshell
            (string-join (append t-args
@@ -578,7 +570,7 @@ tweaked further by the user."
     (if recipe-has-args
         (let* ((cmd-args (justl-jrecipe-args justl-recipe))
                (user-args (mapcar (lambda (arg)
-                                    (format "%s " (justl--util-maybe (justl-jarg-default arg) "")))
+                                    (format "%s " (or (justl-jarg-default arg) "")))
                                   cmd-args)))
           (justl--no-exec-with-eshell
            (string-join (append t-args
@@ -637,7 +629,7 @@ tweaked further by the user."
         (let* ((cmd-args (justl-jrecipe-args justl-recipe))
                (user-args (mapcar (lambda (arg) (read-from-minibuffer
                                                  (format "Just arg for %s:" (justl-jarg-arg arg))
-                                                 (justl--util-maybe (justl-jarg-default arg) "")))
+                                                 (or (justl-jarg-default arg) "")))
                                   cmd-args)))
           (justl--exec justl-executable
                        (append t-args

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,11 +1,7 @@
-FROM fpco/pid1:22.04
+FROM alpine:latest
 
-RUN apt update -y && apt install -y curl
-
-RUN curl -sL https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz | tar xz && mv just /usr/local/bin/just
-
+RUN apk add --no-cache just bash
 RUN mkdir /home/sibi
-
 WORKDIR /home/sibi
 
 COPY justfile /home/sibi/justfile

--- a/test/justfile
+++ b/test/justfile
@@ -1,6 +1,6 @@
 test-variable := "0.2.7"
 
-# List all recipies
+# List all recipes
 default:
     just --list --color never
 

--- a/test/justfile
+++ b/test/justfile
@@ -18,10 +18,6 @@ plan:
 push2 version1 version2:
     echo {{version1}} {{version2}}
 
-[private]
-private_command:
-    echo "private command"
-
 # A target that will fail
 fail:
     exit 1

--- a/test/justfile
+++ b/test/justfile
@@ -18,6 +18,10 @@ plan:
 push2 version1 version2:
     echo {{version1}} {{version2}}
 
+[private]
+private_command:
+    echo "private command"
+
 # A target that will fail
 fail:
     exit 1

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -14,16 +14,6 @@
                  "color")
            (justl--get-recipes "./justfile"))))
 
-(ert-deftest justl--list-to-recipe-test ()
-  (should (equal
-           (justl-jrecipe-name (justl--list-to-jrecipe (list "recipe" "arg")))
-           "recipe"))
-  (should (equal
-           (justl-jrecipe-name (justl--list-to-jrecipe (list "recipe"))) "recipe"))
-  (should (equal
-           (justl-jrecipe-args (justl--list-to-jrecipe (list "recipe")))
-           nil)))
-
 (ert-deftest justl--recipe-has-args-test ()
   (should (equal
            (justl--jrecipe-has-args-p

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -10,8 +10,8 @@
 
 (ert-deftest justl--get-recipes-test ()
   (should (equal
-           (list "build-cmd" "carriage-return" "color" "default" "fail" "plan" "push" "push2")
-           (seq-sort 'string< (mapcar 'justl--recipe-name (justl--get-recipes "./justfile"))))))
+           (list "default" "build-cmd"  "plan" "push" "push2" "fail" "carriage-return" "color")
+           (mapcar 'justl--recipe-name (justl--get-recipes "./justfile")))))
 
 (ert-deftest justl--get-description-test ()
   (let* ((recipes (justl--get-recipes "./justfile"))

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -205,11 +205,11 @@
   (kill-buffer (justl--buffer-name))
   (kill-buffer justl--output-process-buffer))
 
-(ert-deftest justl--find-justfiles-check ()
-  (should (equal (f-filename (justl--find-justfiles default-directory)) "justfile")))
+(ert-deftest justl--find-justfile-check ()
+  (should (equal (f-filename (justl--find-justfile default-directory)) "justfile")))
 
 (ert-deftest justl--get-recipes-with-desc-check ()
-  (let* ((justfile (justl--find-justfiles default-directory))
+  (let* ((justfile (justl--find-justfile default-directory))
          (recipes (justl--get-recipes-with-desc justfile)))
     (should (member (list "default" "List all recipes") recipes))
     (should (member (list "push" nil) recipes))

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -8,11 +8,11 @@
 (require 'ert)
 (require 'f)
 
-(ert-deftest justl--get-recipies-test ()
+(ert-deftest justl--get-recipes-test ()
   (should (equal
            (list "default" "build-cmd" "plan" "push" "push2" "fail" "carriage-return"
                  "color")
-           (justl--get-recipies "./justfile"))))
+           (justl--get-recipes "./justfile"))))
 
 (ert-deftest justl--list-to-recipe-test ()
   (should (equal
@@ -208,12 +208,12 @@
 (ert-deftest justl--find-justfiles-check ()
   (should (equal (f-filename (justl--find-justfiles default-directory)) "justfile")))
 
-(ert-deftest justl--get-recipies-with-desc-check ()
+(ert-deftest justl--get-recipes-with-desc-check ()
   (let* ((justfile (justl--find-justfiles default-directory))
-         (recipies (justl--get-recipies-with-desc justfile)))
-    (should (member (list "default" "List all recipies") recipies))
-    (should (member (list "push" nil) recipies))
-    (should (member (list "push2" nil) recipies))))
+         (recipes (justl--get-recipes-with-desc justfile)))
+    (should (member (list "default" "List all recipes") recipes))
+    (should (member (list "push" nil) recipes))
+    (should (member (list "push2" nil) recipes))))
 
 (ert-deftest justl--execute-recipe-which-prints-carriage-return ()
   "Carriage return should be handled in a way that allows overwriting lines."

--- a/test/justl-test.el
+++ b/test/justl-test.el
@@ -10,147 +10,28 @@
 
 (ert-deftest justl--get-recipes-test ()
   (should (equal
-           (list "default" "build-cmd" "plan" "push" "push2" "fail" "carriage-return"
-                 "color")
-           (justl--get-recipes "./justfile"))))
+           (list "build-cmd" "carriage-return" "color" "default" "fail" "plan" "push" "push2")
+           (seq-sort 'string< (mapcar 'justl--recipe-name (justl--get-recipes "./justfile"))))))
 
-(ert-deftest justl--recipe-has-args-test ()
-  (should (equal
-           (justl--jrecipe-has-args-p
-            (make-justl-jrecipe
-             :name "default"
-             :args nil))
-           nil)))
+(ert-deftest justl--get-description-test ()
+  (let* ((recipes (justl--get-recipes "./justfile"))
+         (recipe (seq-find (lambda (r) (string= "default" (justl--recipe-name r))) recipes)))
+    (should (equal "List all recipes" (justl--recipe-desc recipe)))))
 
-(ert-deftest justl--jrecipe-get-args-test ()
-  (should (equal (justl--jrecipe-get-args
-                  (make-justl-jrecipe
-                   :name "default"
-                   :args nil))
-                 (list)))
-  (should (equal (justl--jrecipe-get-args
-                  (make-justl-jrecipe
-                   :name "default"
-                   :args (list (make-justl-jarg
-                                :arg "version"
-                                :default "'0.4'"))))
-                 (list "version='0.4'")))
-  (should (equal (justl--jrecipe-get-args
-                  (make-justl-jrecipe
-                   :name "default"
-                   :args (list
-                          (make-justl-jarg
-                           :arg "version1"
-                           :default nil)
-                          (make-justl-jarg
-                           :arg "version2"
-                           :default nil))))
-                 (list "version1=" "version2="))))
-
-(ert-deftest justl--is-recipe-line-p-test ()
-  (should (equal
-           (justl--is-recipe-line-p "default:")
-           t))
-  (should (equal
-           (justl--is-recipe-line-p "build-cmd version='0.4':")
-           t))
-  (should (equal
-           (justl--is-recipe-line-p "version := 4.2")
-           nil))
-  (should (equal
-           (justl--is-recipe-line-p "# Terraform plan")
-           nil))
-  (should (equal
-           (justl--is-recipe-line-p "!include lorem.just")
-           nil))
-  (should (equal
-           (justl--is-recipe-line-p "push version: (build-cmd version)")
-           t))
-  (should (equal
-           (justl--is-recipe-line-p "    just --list")
-           nil)))
-
-(ert-deftest justl--get-recipe-from-file-test ()
-  (should (equal
-           (justl--get-recipe-from-file "./justfile" "default")
-           (make-justl-jrecipe :name "default" :args nil)))
-  (should (equal
-           (justl--get-recipe-from-file "./justfile" "plan")
-           (make-justl-jrecipe :name "plan" :args nil)))
-  (should (equal
-           (justl--get-recipe-from-file "./justfile" "push")
-           (make-justl-jrecipe :name "push" :args
-                               (list (make-justl-jarg :arg "version" :default nil)))))
-  (should (equal
-           (justl--get-recipe-from-file "./justfile" "push2")
-           (make-justl-jrecipe :name "push2" :args
-                               (list (make-justl-jarg :arg "version1" :default nil)
-                                     (make-justl-jarg :arg "version2" :default nil))))))
-
-(ert-deftest justl--get-recipe-name-test ()
-  (should (equal
-           (justl--get-recipe-name "default")
-           "default"))
-  (should (equal
-           (justl--get-recipe-name "build-cmd version='0.4'")
-           "build-cmd"))
-  (should (equal
-           (justl--get-recipe-name "    push version")
-           "push"))
-  (should (equal
-           (justl--get-recipe-name "    build-cmd version='0.4' ")
-           "build-cmd"))
-  (should (equal
-           (justl--get-recipe-name "push version:")
-           "push"))
-  (should (equal
-           (justl--get-recipe-name "push version1 version2")
-           "push")))
-
-(ert-deftest justl--str-to-jarg-test ()
-  (should (equal
-           (justl--str-to-jarg "version=0.4")
-           (list (make-justl-jarg :arg "version" :default "0.4"))))
-  (should (equal
-           (justl--str-to-jarg "version='0.4'")
-           (list (make-justl-jarg :arg "version" :default "'0.4'"))))
-  (should (equal
-           (justl--str-to-jarg "version='0.4' version2")
-           (list (make-justl-jarg :arg "version" :default "'0.4'")
-                 (make-justl-jarg :arg "version2" :default nil))))
-  (should (equal
-           (justl--str-to-jarg "version version2")
-           (list (make-justl-jarg :arg "version" :default nil)
-                 (make-justl-jarg :arg "version2" :default nil))))
-  (should (equal (justl--str-to-jarg "") nil)))
-
-(ert-deftest justl--parse-recipe-test ()
-  (should (equal
-           (justl--parse-recipe "default:")
-           (make-justl-jrecipe :name "default" :args nil)))
-  (should (equal
-           (justl--parse-recipe "build-cmd version='0.4':")
-           (make-justl-jrecipe
-            :name "build-cmd"
-            :args (list
-                   (make-justl-jarg
-                    :arg "version"
-                    :default "'0.4'")))))
-  (should (equal (justl--parse-recipe "push version version2:")
-                 (make-justl-jrecipe
-                  :name "push"
-                  :args (list (make-justl-jarg :arg "version" :default nil)
-                              (make-justl-jarg :arg "version2" :default nil)))))
-  (should (equal (justl--parse-recipe "push version: (build-cmd version)")
-                 (make-justl-jrecipe
-                  :name "push"
-                  :args (list (make-justl-jarg :arg "version" :default nil))))))
+(ert-deftest justl--get-recipe-arguments-test ()
+  (let* ((recipes (justl--get-recipes "./justfile"))
+         (push2 (seq-find (lambda (r) (string= "build-cmd" (justl--recipe-name r))) recipes))
+         (args (justl--recipe-args push2)))
+    (should (equal 1 (length args)))
+    (should (equal
+             '("version". "0.4")
+             (cons (justl--arg-name (car args)) (justl--arg-default (car args)))))))
 
 (ert-deftest justl--lists-recipe ()
   (justl)
   (with-current-buffer (justl--buffer-name)
     (let ((buf-string (buffer-string)))
-      (should (s-contains? "plan" buf-string))))
+      (should (search-forward "plan" nil t))))
   (kill-buffer (justl--buffer-name)))
 
 (defun justl--wait-till-exit (buffer)
@@ -197,13 +78,6 @@
 
 (ert-deftest justl--find-justfile-check ()
   (should (equal (f-filename (justl--find-justfile default-directory)) "justfile")))
-
-(ert-deftest justl--get-recipes-with-desc-check ()
-  (let* ((justfile (justl--find-justfile default-directory))
-         (recipes (justl--get-recipes-with-desc justfile)))
-    (should (member (list "default" "List all recipes") recipes))
-    (should (member (list "push" nil) recipes))
-    (should (member (list "push2" nil) recipes))))
 
 (ert-deftest justl--execute-recipe-which-prints-carriage-return ()
   "Carriage return should be handled in a way that allows overwriting lines."


### PR DESCRIPTION
Hi Sibi, I was trying out `justl` but found it didn't work for me because I use [`envrc.el`](https://github.com/purcell/envrc) with per-project tooling and my `just` isn't normally installed globally. Ultimately I expect I'd need to use [`inheritenv`](https://github.com/purcell/inheritenv) to make sure the `justl.el` commands pick up the right local environment. I started digging into the code and found myself tweaking a few things, but still haven't fixed the root problem. In the meantime, here are a bunch of little tweaks and improvements, in separate commits so you follow the reasoning. (I've tested this briefly by installing `just` globally.)