### PR TITLE
Fix just executable argument positioning when setting custom flags

### DIFF
--- a/justl.el
+++ b/justl.el
@@ -355,7 +355,7 @@ Logs the command run."
                              (transient-args 'justl-help-popup)
                              `(,(justl--justfile-argument justfile))))
          (json (apply 'justl--exec-to-string-with-exit-code
-                      (append base-args '("--dump" "--dump-format=json"))))
+                      (delete-dups (append base-args '("--unstable" "--dump" "--dump-format=json")))))
         ;; Obtain the unsorted declaration order separately
         (unsorted-recipes (s-split
                            " "


### PR DESCRIPTION
This commit changes the `justl--parse` and `justl-exec-eshell` functions so that arguments are ordered correctly when calling just: arguments which are destined for just (as in the executable) should be defined before the recipe, since the recipe can have its own arguments.