### PR TITLE
Use buffer-name with recompile to reuse buffer

### DIFF
--- a/justl.el
+++ b/justl.el
@@ -275,7 +275,7 @@ ARGS is a plist that affects how the process is run.
 (defun justl-recompile ()
   "Execute the same just target again."
   (interactive)
-  (justl--make-process justl--compile-command (list :buffer justl--output-process-buffer
+  (justl--make-process justl--compile-command (list :buffer (buffer-name)
                                                     :process "just"
                                                     :directory (if justl-justfile
                                                                    (f-dirname justl-justfile)


### PR DESCRIPTION
When you have `(setq justl-per-recipe-buffer t)` and do a recompile a new buffer will open named `*just*` instead of reusing the buffer from where I am recompiling. The change fixes this issue.

This is the first time I make a contribution to emacs project so please tell me if im doing something wrong.