### PR TITLE
Use the buffer's last command for recompile

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -2,6 +2,8 @@
 
 - Kill process if it's still running before starting a new one in the same
   buffer.
+- Bugfix: Use the buffer's last command for recompile, not the last one across
+  all buffers.
 
 * 0.14
 

--- a/justl.el
+++ b/justl.el
@@ -242,7 +242,7 @@ controls if we are going to display the process status on mode line."
               (eq compilation-scroll-output 'first-error))
           (set (make-local-variable 'compilation-auto-jump-to-next) t)))))
 
-(defvar justl--compile-command nil
+(defvar-local justl--compile-command nil
   "Last shell command used to do a compilation; default for next compilation.")
 
 (defun justl--make-process (command &optional args)


### PR DESCRIPTION
This makes `justl-recompile` execute the last just target that was executed in that buffer, not the last one across all buffers. Without this, using `justl-recompile` with `justl-per-recipe-buffer` has really surprising behaviour.