### PR TITLE
Kill process if it's still running before starting a new one

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -1,3 +1,8 @@
+* Unreleased
+
+- Kill process if it's still running before starting a new one in the same
+  buffer.
+
 * 0.14
 
 - Respect buffer-local environments, for compatibility with ~envrc.el~

--- a/justl.el
+++ b/justl.el
@@ -285,6 +285,21 @@ ARGS is a plist that affects how the process is run.
 (defun justl-recompile ()
   "Execute the same just target again."
   (interactive)
+  ;; This is copied and adapted from `compilation-start'.
+  (let ((comp-proc (get-buffer-process (current-buffer))))
+    (if comp-proc
+        (if (or (not (eq (process-status comp-proc) 'run))
+                (eq (process-query-on-exit-flag comp-proc) nil)
+                (yes-or-no-p "The last target is still running; kill it? "))
+            (condition-case ()
+                (progn
+                  (interrupt-process comp-proc)
+                  (sit-for 1)
+                  (delete-process comp-proc))
+              (error nil))
+          (error "Cannot have two processes in `%s' at once"
+                 (buffer-name)))))
+
   (justl--make-process justl--compile-command (list :buffer (buffer-name)
                                                     :process "just"
                                                     :directory (if justl-justfile


### PR DESCRIPTION
I have several just recipes that will start long running processes (e.g. servers). I'd like to be able to restart them using `justl-recompile` and keep only one of them active at all times (just like with a regular compile command).

This PR takes the relevant piece of code from `compilation-start` and incorporates it into `justl-recompile`.