### PR TITLE
Added option justl-pop-to-buffer-on-display

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -14,6 +14,9 @@
   with no-cd recipe attribute.
 - Justl buffer names are changed to include filename too. This is made
   in preparation for supporting just modules.
+- Add ~justl-pop-to-buffer-on-display~. When on, input focus moves to the justl
+  buffer when it is displayed (the previous behavior). Otherwise the buffer is
+  displayed without selecting it. (defaults to on).
 
 * 0.14
 

--- a/justl.el
+++ b/justl.el
@@ -132,6 +132,12 @@ package to be installed."
                  (const vterm))
   :group 'justl)
 
+(defcustom justl-pop-to-buffer-on-display t
+  "If non-nil, selects the justl buffer when it is displayed.
+If nil, displays the buffer without selecting it."
+  :type 'boolean
+  :safe 'booleanp)
+
 (defun justl--recipe-output-buffer (recipe-name)
   "Return the buffer name for the RECIPE-NAME."
   (if justl-per-recipe-buffer
@@ -146,7 +152,10 @@ package to be installed."
   "Utility function to pop to buffer or create it.
 
 NAME is the buffer name."
-  (pop-to-buffer-same-window (get-buffer-create name)))
+  (let ((buf (get-buffer-create name)))
+    (if justl-pop-to-buffer-on-display
+        (pop-to-buffer-same-window buf)
+      (display-buffer buf display-buffer--same-window-action))))
 
 (defconst justl--process-buffer "*just-process*"
   "Just process buffer name.")
@@ -281,7 +290,9 @@ ARGS is a plist that affects how the process is run.
         (set-process-filter process 'justl--process-filter)
         (set-process-sentinel process (lambda (proc _) (justl--sentinel proc buf)))
         (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix)
-        (pop-to-buffer buf)))))
+        (if justl-pop-to-buffer-on-display
+            (pop-to-buffer buf)
+          (display-buffer buf))))))
 
 (defvar justl-compile-mode-map
   (let ((map (make-sparse-keymap)))
@@ -388,7 +399,9 @@ ARGS is a ist of arguments."
                                    :process process-name
                                    :directory default-directory
                                    :mode mode)))
-  (pop-to-buffer justl--output-process-buffer))
+  (if justl-pop-to-buffer-on-display
+      (pop-to-buffer justl--output-process-buffer)
+    (display-buffer justl--output-process-buffer)))
 
 (defun justl--exec-to-string-with-exit-code (executable &rest args)
   "Run EXECUTABLE with ARGS, throwing an error if the command fails.

--- a/justl.el
+++ b/justl.el
@@ -136,6 +136,7 @@ package to be installed."
   "If non-nil, selects the justl buffer when it is displayed.
 If nil, displays the buffer without selecting it."
   :type 'boolean
+  :group 'justl
   :safe 'booleanp)
 
 (defun justl--recipe-output-buffer (recipe-name)


### PR DESCRIPTION
Resolves issue #67 

The current behaviour is that the justl buffer is selected when a command is run. This adds the option to make that behaviour optional, so it can display the buffer without selecting it.

