### PR TITLE
Fix for issue with justl-pop-to-buffer-on-display

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -15,8 +15,8 @@
 - Justl buffer names are changed to include filename too. This is made
   in preparation for supporting just modules.
 - Add ~justl-pop-to-buffer-on-display~. When on, input focus moves to the justl
-  buffer when it is displayed (the previous behavior). Otherwise the buffer is
-  displayed without selecting it. (defaults to on).
+  output buffer when it is displayed (the previous behavior). Otherwise the
+  output buffer is displayed without selecting it. (defaults to on).
 - Better defgroup integration.
 
 * 0.14

--- a/justl.el
+++ b/justl.el
@@ -133,8 +133,8 @@ package to be installed."
   :group 'justl)
 
 (defcustom justl-pop-to-buffer-on-display t
-  "If non-nil, selects the justl buffer when it is displayed.
-If nil, displays the buffer without selecting it."
+  "If non-nil, selects the justl output buffer when it is displayed.
+If nil, displays the output buffer without selecting it."
   :type 'boolean
   :group 'justl
   :safe 'booleanp)
@@ -153,10 +153,7 @@ If nil, displays the buffer without selecting it."
   "Utility function to pop to buffer or create it.
 
 NAME is the buffer name."
-  (let ((buf (get-buffer-create name)))
-    (if justl-pop-to-buffer-on-display
-        (pop-to-buffer-same-window buf)
-      (display-buffer buf display-buffer--same-window-action))))
+  (pop-to-buffer-same-window (get-buffer-create name)))
 
 (defconst justl--process-buffer "*just-process*"
   "Just process buffer name.")


### PR DESCRIPTION
Fixes #72

When running 'justl' while `justl-pop-to-buffer-on-display` was set to nil, a blank buffer would be displayed.

This was caused by a misunderstanding of the purpose of `justl--pop-to-buffer`; the new option is only intended to apply to compilation/output buffers, rather than interaction buffers, and `justl--pop-to-buffer` is only used for interaction buffers.

The fix is to simply revert the behaviour of `justl--pop-to-buffer`, so it is unaffected by the new option.

Also updated the option description and the changelog to be more explicit about which buffers the option is for.