### PR TITLE
ci: Update tested Emacs versions in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,9 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
+          - 30.1
           - 29.3
-          - 29.2
-          - 29.1
           - 28.2
           - 27.2
         ignore_warnings:


### PR DESCRIPTION
This commit updates the matrix of Emacs versions tested in the GitHub Actions CI workflow. It removes older versions 29.1 and 29.2 and adds the newer 30.1 release to ensure testing against more current Emacs versions while maintaining a reasonable matrix size.