### PR TITLE
Check for fallback location with JUST_JUSTFILE environment variable

### DIFF
--- a/justl.el
+++ b/justl.el
@@ -188,7 +188,7 @@ was found."
 
 DIR represents the directory where search will be carried out.
 It searches either for the filename justfile or .justfile"
-  (when-let ((justfile-path (justl--find-any-justfile dir)))
+  (when-let ((justfile-path (or (justl--find-any-justfile dir) (getenv "JUST_JUSTFILE"))))
     (setq-local justl-justfile justfile-path)
     justfile-path))
 


### PR DESCRIPTION
Allows using the path set in `JUST_JUSTFILE` when no file is found. It has been added to just in this PR https://github.com/casey/just/pull/2044/files